### PR TITLE
testing trunk move (Stack #1 of 1, PR #2 of 3)

### DIFF
--- a/testing trunk move/1/file2.md
+++ b/testing trunk move/1/file2.md
@@ -1,0 +1,2 @@
+# Content for Stack 1, Iteration 2
+quis do veniam sit aliqua sed ipsum tempor sed incididunt incididunt exercitation nostrud ad magna nostrud incididunt eiusmod et ipsum adipiscing dolor sit lorem adipiscing nostrud enim aliqua dolore 


### PR DESCRIPTION
Simplify the `S3AccessPoint` helper:

- Each ARN component takes a config override OR falls back to `Ec2Metadata` (IMDSv2). Drops the `node['aws'][...]` fallback chain that silently produced malformed ARNs when the ohai `aws` plugin didn't populate (the prod piezo failure mode from #13257).
- Rename the config key `access_point_account_id` → `account_id`.
- Drop the `use_access_point` flag — the helper is unconditionally the AP. The flag's dead `use_access_point=false` branch had no live default-true consumers anyway.
- Pin `region = 'us-east-1'` in `certbot` and `lucid-haproxy::certificate` attrs (staging's lucidbag AP lives in us-east-1). Lets workstation callers — where IMDS isn't reachable — resolve a well-formed ARN.

## Test plan

- [x] `cinc exec rspec cookbooks/lucid-util/spec/unit/libraries/s3_access_point_spec.rb`

```
<Icon
        aria-hidden
        color={enabled ? "green" : "tertiary"}
        name={enabled ? "check" : "x"}
        size="sm"
      />
```

- [x] cookstyle clean on touched files

```
gh search code --owner lucid-software-internal 'access_point_account_id'        --limit 50
gh search code --owner lucid-software-internal 'lucid_utility use_access_point' --limit 50
gh search code --owner lucid-software-internal 'lucid_utility bucket'           --limit 50
```

- [x] **`lucid-haproxy::workstation_certs`** **live on a workstation (the meaningful upgrade)** — branch-override on `pharrison.dev.lucidvpc.com` and verified the recipe now renders a well-formed ARN and the cert sync still succeeds:

    Rendered template:

    (Pre-PR this was `arn:aws:s3::750787311880:accesspoint/lucidbag` — missing region.)

    Forced sync after the override:

    Clean exit, no `botocore Invalid ARN`.

```
gh search code --owner lucid-software-internal 'access_point_account_id'        --limit 50
gh search code --owner lucid-software-internal 'lucid_utility use_access_point' --limit 50
gh search code --owner lucid-software-internal 'lucid_utility bucket'           --limit 50
```

- [ ] **`certbot::s3_generate`** **live on the** **`staging-certbot`** **host** — the other live `S3AccessPoint.bucket_ref(node, node['certbot'])` consumer (cookbooks/certbot/recipes/s3_generate.rb:18). Branch-override + converge, then verify the rendered `/etc/letsencrypt/renewal-hooks/deploy/certsync` carries the well-formed ARN, and trigger the hook to confirm a clean upload:

    Rendered template: Testy text

    Forced sync:

    Expect exit 0 with no `botocore Invalid ARN`; the `aws s3 cp` lines should each succeed.
- [ ] **`lucid_utility`** **schema-change sweep** — `bucket`, `use_access_point`, and `access_point_account_id` are all gone from `node['lucid_utility']`. No in-repo recipe reads these today, but external repos / data bags / role+env overrides could. Grep the org for stragglers:

    Resolve any hits before merge (or call them out as a follow-up).
- [ ] **EC2 path** — covered by the upstack #13257 piezo verification on `piezo-10-6-131-69.preprod.lucidvpc.com`, which exercises the same library code (per-account ARN built from IMDS).